### PR TITLE
Update windows baselines

### DIFF
--- a/windowsbuild/testing_baselines/databases/chgcar/parallel/chgcar_05.png
+++ b/windowsbuild/testing_baselines/databases/chgcar/parallel/chgcar_05.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a41db1bab64901a39f285e972556dafcd58562b03dc07be6cdd30f59b879cc24
-size 43894
+oid sha256:21d61c9751b3502f05cf29ad3d39ec0fa24835d2037d90b88bee88c4d74222d5
+size 43842

--- a/windowsbuild/testing_baselines/databases/chgcar/parallel/chgcar_07.png
+++ b/windowsbuild/testing_baselines/databases/chgcar/parallel/chgcar_07.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11774ebfd008903aa0559845b1294d51b7815af6498262c19d70f1ab02d1bf27
-size 45985
+oid sha256:f2e63e03e527158475616689c5a5b4a38fa78e5fcd5fd0d3c3d7abc3681a6f39
+size 46019

--- a/windowsbuild/testing_baselines/databases/chgcar/parallel/chgcar_11.png
+++ b/windowsbuild/testing_baselines/databases/chgcar/parallel/chgcar_11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:315623fc8d6cd98c62944e6178f2f8f424cdee44be5ad90e7f68f0f56dea7e7c
-size 15192
+oid sha256:d2a1b1bc10938b404a8d9b7cd35da22ca2654f06141f04c0960fd920d1bc41e9
+size 14963

--- a/windowsbuild/testing_baselines/databases/xdmf/xdmf_4_02.png
+++ b/windowsbuild/testing_baselines/databases/xdmf/xdmf_4_02.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e255a5c2cc079bf052e0b1491f16d315ff40df9eb92b8598744e5c7c0d26eed3
-size 912
+oid sha256:b423fdba2a2b8d891e9c0d1941a34f4269f3e1749620a8fe8ea7244ec4872dbd
+size 5672

--- a/windowsbuild/testing_baselines/databases/xdmf/xdmf_4_04.png
+++ b/windowsbuild/testing_baselines/databases/xdmf/xdmf_4_04.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e255a5c2cc079bf052e0b1491f16d315ff40df9eb92b8598744e5c7c0d26eed3
-size 912
+oid sha256:9a06f5a62dd3201cd30e4621ac0600031338b770a077fa23126c1d0a946cd2d0
+size 3122

--- a/windowsbuild/testing_baselines/operators/ic_pathlines/ic_pathlines_02.png
+++ b/windowsbuild/testing_baselines/operators/ic_pathlines/ic_pathlines_02.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:493cf09be2492c1c0d538d1696ac7259e307ff0422e029781415be3b7e52ade2
+oid sha256:46f5ae1fb521dd8074a9879c54f4263dfdfcd0caafe63b91096b5b85d37a4436
 size 2415

--- a/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0000.png
+++ b/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0000.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b675a137ac1ce101fb50fe93d994dbed0e9f20bb09f26e2cf7eb349dea47ab92
-size 5524
+oid sha256:22f6f2f6a24a3b0e88e0c778c53b78470b0f3d6c61407c09bd1c3ff6d6b7d34c
+size 5393

--- a/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0001.png
+++ b/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0001.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:debf463bbc11da2a35c1e31d65db6b1b70b06994ae508acaa1bbfd3e0faf69b4
-size 5792
+oid sha256:20335e4b2893130f68e18283d1c39b75f3937676be2826993ae2e47e1e4bd73d
+size 5878

--- a/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0002.png
+++ b/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0002.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13d868c3595846bb84d33b182d348560ec5ab73c6721d74c49306a3be3a4f578
-size 5715
+oid sha256:9a681d6a4c02de6592ee947be0228f95b80f6ab1289b1bea8790b96edb7ac3b8
+size 5727

--- a/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0003.png
+++ b/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0003.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c73da6172e3e1341417dc6afec29ba6776d594de9b9dbdfe090dfc63b52a1a1
-size 6149
+oid sha256:17e0e2518ea6b1943536438971089e35292a13fb08d8d79802d253bd8a34c2af
+size 6040

--- a/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0004.png
+++ b/windowsbuild/testing_baselines/queries/surface_area_over_time/SA_OverTime_0004.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7fc6e6b14ce4feae6080e9d63c36b31107a26a717bd60242adef4ce5d136068d
-size 5537
+oid sha256:8a814686f5c22c11f3f4c2ec42068bb2268a4044d98aaf6f461f9d6ec49a439d
+size 5472


### PR DESCRIPTION
Due to tests being removed from skiplist.
These files mistakenly forgotten in last commit/merge.