### PR TITLE
Updates to installer creation scripting.

### DIFF
--- a/windowsbuild/BuildScripts/CreateSignedRelease.bat
+++ b/windowsbuild/BuildScripts/CreateSignedRelease.bat
@@ -89,19 +89,19 @@ Rem create the install dir that will be packaged
 msbuild INSTALL.vcxproj /p:Configuration=Release /m:4 /flp1:warningsonly;logfile=package.warn /flp2:errorsonly;logfile=package.error
 
 Rem sign the executables that will be packaged
-signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt %VVERS%"\*.exe 
+signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt%VVERS%"\*.exe 
 
-signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt %VVERS%"\*.dll 
+signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt%VVERS%"\*.dll 
 
-signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt %VVERS%"\databases\*.dll 
-signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt %VVERS%"\operators\*.dll 
-signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt %VVERS%"\plots\*.dll
+signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt%VVERS%"\databases\*.dll 
+signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt%VVERS%"\operators\*.dll 
+signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt%VVERS%"\plots\*.dll
  
 Rem Create the installer 
 msbuild _Package.vcxproj /p:Configuration=Release /m:4 /flp1:warningsonly;logfile=package.warn /flp2:errorsonly;logfile=package.error
 
 Rem Sign the installer 
-signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "VisIt %VVERS%"\visit%VVERS%_x64.exe 
+signtool sign /q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a /sha1 %CSHash% "visit%VVERS%_x64.exe 
 
 
 cd %VRootDir%

--- a/windowsbuild/distribution/installation/CreateDBSections.nsi
+++ b/windowsbuild/distribution/installation/CreateDBSections.nsi
@@ -4,7 +4,7 @@
 #
 # Purpose: This script compares database names with build database dlls to
 #          create a list of database plugins that can be installed. They are
-#          then stored in their own NSIS sections, so that they can be 
+#          then stored in their own NSIS sections, so that they can be
 #          selectively chosen to be installed or not, one by one.
 #
 # Notes:  Expects VISIT_SOURCE_DIR and INSTALL_PREFIX to be defined on
@@ -13,6 +13,11 @@
 # Modifications:
 #   Kathleen Biagas, Thu Sep 15 12:33:15 PDT 2011
 #   Add logic to exclude parallel files if necessary.
+#
+#   Kathleen Biagas, Wed Jun 29, 2022
+#   Modified to simply create empty section for each avaialable DB plugin.
+#   Having the sections allows user to unselect DB plugins for install.
+#   No copy logic needed, as the entire Install is now in a compressed 7z.
 #
 ##############################################################################
 
@@ -25,43 +30,32 @@ OutFile "${BIN_DIR}\CreateDBSections.exe"
 SilentInstall silent
 
 var NumDBPlugins
-var DBOutPath
 var DBInPath
-var tmpfile
-var myesc
 
 Section DBS
     StrCpy $NumDBPlugins 0
-    StrCpy $DBOutPath "${VISITINSTDIR}\databases"
     StrCpy $DBInPath "${INSTALL_PREFIX}\databases\"
-    StrCpy $myesc "$$"
 
     FileOpen $0 "${BIN_DIR}\DBSections.txt" w #open file
     FileWrite $0 `SectionGroup "Database Plugins" SEC_DP$\r$\n`
 
     FindFirst $R1 $R2 "${VISIT_SOURCE_DIR}\databases\*"
-   
+
     ${Unless} ${Errors}
       ${Do}
-        StrCpy $tmpfile "$DBInPathI$R2Database.dll" 
-        ${If} ${FileExists} "$DBInPathI$R2Database.dll" 
+        ${If} ${FileExists} "$DBInPathI$R2Database.dll"
+            # create empty section, simply to add ability for user to
+            # unselect database plugins
             FileWrite $0 `    Section "$R2"  SEC_DP_$NumDBPlugins$\r$\n`
-            FileWrite $0 `        SetOutPath "$DBOutPath"$\r$\n`
-            FileWrite $0 `        $myesc{If} $myesc{SectionIsSelected} "${SEC_PAR}"$\r$\n`
-            FileWrite $0 `            File "$DBInPath*$R2*.dll"$\r$\n`
-            FileWrite $0 `        $myesc{Else}$\r$\n`
-            FileWrite $0 `            File /x "*_par.dll" "$DBInPath*$R2*.dll"$\r$\n`
-            FileWrite $0 `        $myesc{EndIf}$\r$\n`
             FileWrite $0 `    SectionEnd$\r$\n`
-            IntOp $NumDBPlugins $NumDBPlugins + 1 
-        ${EndIf}        
+            IntOp $NumDBPlugins $NumDBPlugins + 1
+        ${EndIf}
         FindNext $R1 $R2
-      ${LoopUntil} ${Errors} 
+      ${LoopUntil} ${Errors}
       FindClose $R1
     ${EndUnless}
-    FileWrite $0 `SectionGroupEnd$\r$\n`  
+    FileWrite $0 `SectionGroupEnd$\r$\n`
     FileWrite $0 `!define NumDBPlugins "$NumDBPlugins"$\r$\n`
-
     FileClose $0
 SectionEnd
 


### PR DESCRIPTION
Was exceeding 2GB size limit for NSIS, so opted to 7zip all the install files (result of 'make install' command) with lzma2 and 'ultra' compression.
Installer creation script was modified to install the 7zipd file (and 7z.exe and dll) to temp location, then call 7z.exe to extract from the 7zipd file to the install location.
Only optional sections were retained, even if they are now empty, to continue to allow users to opt out of certain things for installation (like data, help, plugin development files, specific database plugins).
Also removed the space in the install dir 'VisIt ' became 'Visit'.