### PR TITLE
Rebuild mfem-4.4 with a few hacks to fix VisIt build issues.

### DIFF
--- a/windowsbuild/MSVC2017/mfem/4.4/include/mfem/fem/datacollection.hpp
+++ b/windowsbuild/MSVC2017/mfem/4.4/include/mfem/fem/datacollection.hpp
@@ -376,12 +376,12 @@ public:
    virtual ~DataCollection();
 
    /// Errors returned by Error()
-   enum { NO_ERROR = 0, READ_ERROR = 1, WRITE_ERROR = 2 };
+   enum { MFEM_NO_ERROR = 0, READ_ERROR = 1, WRITE_ERROR = 2 };
 
    /// Get the current error state
    int Error() const { return error; }
    /// Reset the error state
-   void ResetError(int err_state = NO_ERROR) { error = err_state; }
+   void ResetError(int err_state = MFEM_NO_ERROR) { error = err_state; }
 
 #ifdef MFEM_USE_MPI
    friend class ParMesh;

--- a/windowsbuild/MSVC2017/mfem/4.4/include/mfem/general/globals.hpp
+++ b/windowsbuild/MSVC2017/mfem/4.4/include/mfem/general/globals.hpp
@@ -119,7 +119,12 @@ void SetGlobalMPI_Comm(MPI_Comm comm);
 #if defined(__GNUC__) || defined(__clang__)
 #define MFEM_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER)
-#define MFEM_DEPRECATED __declspec(deprecated)
+// using __declspec(deprecated) causes unnecessary warnings whenever a header
+// that uses MFEM_DEPRECATED is included in another project regardless of
+// whether or not the project is actually using the deprecated method.
+// Commented out here to to reduce excessive warning noise during compilation
+//#define MFEM_DEPRECATED __declspec(deprecated)
+#define MFEM_DEPRECATED
 #else
 #pragma message("WARNING: You need to implement MFEM_DEPRECATED for this compiler")
 #define MFEM_DEPRECATED

--- a/windowsbuild/MSVC2017/mfem/4.4/lib/mfem.lib
+++ b/windowsbuild/MSVC2017/mfem/4.4/lib/mfem.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1d3f8fed6c7be46e8ec5d712cbef2df730736f3e102a289b182e220bcdb4a55
-size 42308068
+oid sha256:95e748151a9c4919a8b98d15c55c78112df04fb065821778fd541610a39c1f31
+size 42308090


### PR DESCRIPTION
datacollection.hpp: change 'NO_ERROR' to 'MFEM_NO_ERROR' because 'NO_ERROR' is #defined in a windows header and causes VisIt compilation failure due to the name collision.  Necessary mfem source files were also changed to use the new name and the library was recompiled.  The name change didn't cause any issues with VisIt's use of mfem.

globals.hpp:  Removed ' __declspec(deprecated)' from the definition of MFEM_DEPRECATED, because it causes a lot of warning messages during VisIt compilation whenever a header that uses MFEM_DEPRECATED is #included, even if the deprecated functions aren't being used.  The warnings cannot be fixed any other way.